### PR TITLE
lava-action: add forcecolor input parameter

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -4,11 +4,14 @@ name: Lava
 description: Run Lava
 inputs:
   version:
-    description: Lava version
+    description: Lava version.
     default: latest
   config:
-    description: Path of the Lava configuration file
+    description: Path of the Lava configuration file.
     default: lava.yaml
+  forcecolor:
+    description: Force colorized output.
+    default: true
 outputs:
   status:
     description: Status code
@@ -34,3 +37,4 @@ runs:
       shell: bash
       env:
         LAVA_CONFIG: ${{ inputs.config }}
+        LAVA_FORCECOLOR: ${{ inputs.forcecolor }}

--- a/run.bash
+++ b/run.bash
@@ -10,9 +10,14 @@ if [[ -z $LAVA_CONFIG ]]; then
 	exit 2
 fi
 
+if [[ -z $LAVA_FORCECOLOR ]]; then
+	echo 'error: missing env var LAVA_FORCECOLOR' >&2
+	exit 2
+fi
+
 output=$(mktemp)
 
-lava run -c "${LAVA_CONFIG}" > "${output}"
+lava run -forcecolor="${LAVA_FORCECOLOR}" -c "${LAVA_CONFIG}" > "${output}"
 status=$?
 
 echo "status=${status}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
This PR introduces a new input parameter called `forcecolor`, which
allows to enable Lava run's `-forcecolor` flag.

This PR updates the Lava version used in the test workflow to
temporarily point to the `force-color` branch corresponding to the
following PR:

- https://github.com/adevinta/lava/pull/26.

After merging the PR this change will be dropped (commit message
starting with `[drop]`).

Output:

![image](https://github.com/adevinta/lava-action/assets/1223476/f12da1ff-cb4d-4c83-a750-f65d67739f9b)