### PR TITLE
lava-action: update "lava run" to "lava scan"

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -17,7 +17,7 @@ fi
 
 output=$(mktemp)
 
-lava run -forcecolor="${LAVA_FORCECOLOR}" -c "${LAVA_CONFIG}" > "${output}"
+lava scan -forcecolor="${LAVA_FORCECOLOR}" -c "${LAVA_CONFIG}" > "${output}"
 status=$?
 
 echo "status=${status}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
This PR updates `run.bash` to change `lava run` to `lava scan`.

Related PR:

- https://github.com/adevinta/lava/pull/32