### PR TITLE
lava-action: provide default Lava configuration

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,10 +4,10 @@ name: Main
 on: [push, pull_request]
 permissions:
   contents: read
-env:
-  WANT_STATUS: 103 # ExitCodeHigh
 jobs:
   test:
+    env:
+      WANT_STATUS: 103 # ExitCodeHigh
     name: Test
     runs-on: ubuntu-latest
     steps:
@@ -28,4 +28,25 @@ jobs:
         if: ${{ steps.lava.outputs.status != env.WANT_STATUS }}
         run: |
           echo "::error::unexpected status code: got: ${{ steps.lava.outputs.status }}, want: ${{ env.WANT_STATUS }}"
+          exit 1
+  test-defaults:
+    env:
+      WANT_MIN_STATUS: 103 # ExitCodeHigh
+    name: Test Defaults
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Lava Action
+        id: lava
+        uses: ./
+        continue-on-error: true
+      - name: Print status
+        run: 'echo "Lava status: ${{ steps.lava.outputs.status }}"'
+      - name: Print report
+        run: 'cat "${{ steps.lava.outputs.report }}"'
+      - name: Report unexpected status
+        if: ${{ steps.lava.outputs.status < env.WANT_MIN_STATUS }}
+        run: |
+          echo "::error::unexpected status code: got: ${{ steps.lava.outputs.status }}, want: >= ${{ env.WANT_MIN_STATUS }}"
           exit 1

--- a/action.yaml
+++ b/action.yaml
@@ -3,12 +3,11 @@
 name: Lava
 description: Run Lava
 inputs:
+  config:
+    description: Path of the Lava configuration file.
   version:
     description: Lava version.
     default: latest
-  config:
-    description: Path of the Lava configuration file.
-    default: lava.yaml
   forcecolor:
     description: Force colorized output.
     default: true

--- a/default.yaml
+++ b/default.yaml
@@ -1,0 +1,14 @@
+# Copyright 2023 Adevinta
+
+lava: v0.0.0
+logLevel: error
+checktypesURLs:
+  # TODO(rm): update URL.
+  - https://raw.githubusercontent.com/adevinta/vulcan-local/master/resources/checktypes.json
+targets:
+  - identifier: .
+    assetType: GitRepository
+agent:
+  parallel: 4
+report:
+  severity: high

--- a/run.bash
+++ b/run.bash
@@ -1,12 +1,14 @@
 # Copyright 2023 Adevinta
 
-if [[ -z $GITHUB_OUTPUT ]]; then
-	echo 'error: missing env var GITHUB_OUTPUT' >&2
+# Check mandatory environment variables.
+
+if [[ -z $GITHUB_ACTION_PATH ]]; then
+	echo 'error: missing env var GITHUB_ACTION_PATH' >&2
 	exit 2
 fi
 
-if [[ -z $LAVA_CONFIG ]]; then
-	echo 'error: missing env var LAVA_CONFIG' >&2
+if [[ -z $GITHUB_OUTPUT ]]; then
+	echo 'error: missing env var GITHUB_OUTPUT' >&2
 	exit 2
 fi
 
@@ -15,9 +17,17 @@ if [[ -z $LAVA_FORCECOLOR ]]; then
 	exit 2
 fi
 
+# Run Lava.
+
+config=$LAVA_CONFIG
+if [[ -z $config ]]; then
+	config=$(mktemp -p .)
+	cp "${GITHUB_ACTION_PATH}/default.yaml" "${config}"
+fi
+
 output=$(mktemp)
 
-lava scan -forcecolor="${LAVA_FORCECOLOR}" -c "${LAVA_CONFIG}" > "${output}"
+lava scan -forcecolor="${LAVA_FORCECOLOR}" -c "${config}" > "${output}"
 status=$?
 
 echo "status=${status}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
This PR makes the `config` input parameter optional. If `config` is
not specified, `lava-action` provides a default Lava configuration
that points to a remote checktype catalog.

The URL of the current checktype catalog is temporary and will be
change once the final catalog has been deployed.