### PR TITLE
lava-action: remove checkout step

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,8 +21,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
     - name: Set up Go
       uses: actions/setup-go@v4
       with:


### PR DESCRIPTION
This PR removes the `checkout` step from the action. It should be the
user the one that decides what repository is checked out (if any).