### PR TITLE
default.yaml: update checktype catalog URL

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -3,8 +3,7 @@
 lava: v0.0.0
 logLevel: error
 checktypesURLs:
-  # TODO(rm): update URL.
-  - https://raw.githubusercontent.com/adevinta/vulcan-local/master/resources/checktypes.json
+  - https://github.com/adevinta/lava-resources/releases/download/checktypes/v0/checktypes.json
 targets:
   - identifier: .
     assetType: GitRepository


### PR DESCRIPTION
This PR updates the references to the old checktype catalog URL to
depend on the version published in the adevinta/lava-resources
repository.