### PR TITLE
README.md: remove duplicated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This action runs [Lava][lava] in your GitHub Actions workflows.
 
-[Lava][lava] is an open source vulnerability scanner that makes it
-easy to run security checks in your local and CI/CD environments.
+Lava is an open source vulnerability scanner that makes it easy to run
+security checks in your local and CI/CD environments.
 
 ## Usage
 


### PR DESCRIPTION
This PR removes one of the links to the Lava repository. It keeps only
the first appearance.