### PR TITLE
lava-action: try to download a Lava release from GitHub

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,7 @@ jobs:
   test-defaults:
     env:
       WANT_MIN_STATUS: 103 # ExitCodeHigh
-    name: Test Defaults
+    name: Test defaults
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -49,4 +49,52 @@ jobs:
         if: ${{ steps.lava.outputs.status < env.WANT_MIN_STATUS }}
         run: |
           echo "::error::unexpected status code: got: ${{ steps.lava.outputs.status }}, want: >= ${{ env.WANT_MIN_STATUS }}"
+          exit 1
+  test-release:
+    env:
+      WANT_STATUS: 103 # ExitCodeHigh
+    name: Test release download
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Lava Action
+        id: lava
+        uses: ./
+        with:
+          version: v0.2.0
+          config: testdata/lava.yaml
+        continue-on-error: true
+      - name: Print status
+        run: 'echo "Lava status: ${{ steps.lava.outputs.status }}"'
+      - name: Print report
+        run: 'cat "${{ steps.lava.outputs.report }}"'
+      - name: Report unexpected status
+        if: ${{ steps.lava.outputs.status != env.WANT_STATUS }}
+        run: |
+          echo "::error::unexpected status code: got: ${{ steps.lava.outputs.status }}, want: ${{ env.WANT_STATUS }}"
+          exit 1
+  test-branch:
+    env:
+      WANT_STATUS: 103 # ExitCodeHigh
+    name: Test "go install" fallback
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Lava Action
+        id: lava
+        uses: ./
+        with:
+          version: main
+          config: testdata/lava.yaml
+        continue-on-error: true
+      - name: Print status
+        run: 'echo "Lava status: ${{ steps.lava.outputs.status }}"'
+      - name: Print report
+        run: 'cat "${{ steps.lava.outputs.report }}"'
+      - name: Report unexpected status
+        if: ${{ steps.lava.outputs.status != env.WANT_STATUS }}
+        run: |
+          echo "::error::unexpected status code: got: ${{ steps.lava.outputs.status }}, want: ${{ env.WANT_STATUS }}"
           exit 1

--- a/action.yaml
+++ b/action.yaml
@@ -25,13 +25,11 @@ runs:
       uses: actions/setup-go@v4
       with:
         go-version: '1.21'
-    - name: Install Lava
-      run: 'go install "github.com/adevinta/lava/cmd/lava@${{ inputs.version }}"'
-      shell: bash
     - name: Run Lava
       id: lava
       run: '"${GITHUB_ACTION_PATH}/run.bash"'
       shell: bash
       env:
+        LAVA_VERSION: ${{ inputs.version }}
         LAVA_CONFIG: ${{ inputs.config }}
         LAVA_FORCECOLOR: ${{ inputs.forcecolor }}

--- a/run.bash
+++ b/run.bash
@@ -1,5 +1,31 @@
 # Copyright 2023 Adevinta
 
+GH_DOWNLOAD_URL_FMT='https://github.com/adevinta/lava/releases/download/%s/lava_linux_amd64.tar.gz'
+GH_DOWNLOAD_URL_LATEST='https://github.com/adevinta/lava/releases/latest/download/lava_linux_amd64.tar.gz'
+
+install_lava() {
+	local version=$1
+
+	local url
+	if [[ $version == 'latest' ]]; then
+		url=$GH_DOWNLOAD_URL_LATEST
+	else
+		url=$(printf "${GH_DOWNLOAD_URL_FMT}" "${version}")
+	fi
+
+	# Make sure the install directory exists.
+	install_dir="$(go env GOPATH)/bin"
+	mkdir -p "${install_dir}"
+
+	# Try to download a Lava release from GitHub.
+	if (curl -LsSf "${url}" | tar -xz -C "${install_dir}" lava) 2> /dev/null; then
+		return 0
+	fi
+
+	# Fallback to "go install".
+	go install "github.com/adevinta/lava/cmd/lava@${version}"
+}
+
 # Check mandatory environment variables.
 
 if [[ -z $GITHUB_ACTION_PATH ]]; then
@@ -12,9 +38,21 @@ if [[ -z $GITHUB_OUTPUT ]]; then
 	exit 2
 fi
 
+if [[ -z $LAVA_VERSION ]]; then
+	echo 'error: missing env var LAVA_VERSION' >&2
+	exit 2
+fi
+
 if [[ -z $LAVA_FORCECOLOR ]]; then
 	echo 'error: missing env var LAVA_FORCECOLOR' >&2
 	exit 2
+fi
+
+# Install Lava.
+
+if ! install_lava "${LAVA_VERSION}"; then
+	echo 'error: could not install lava' >&2
+	exit 1
 fi
 
 # Run Lava.

--- a/testdata/lava.yaml
+++ b/testdata/lava.yaml
@@ -1,4 +1,4 @@
-lava: v1.0.0
+lava: v0.0.0
 checktypes:
   - testdata/checktypes.json
 targets:


### PR DESCRIPTION
This PR changes `run.bash` to try to download a Lava release with the
provided version. If it does not exists, it fallbacks to `go install`.
This reduces the Lava installation time considerably.