### PR TITLE
.github/workflows: add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+# Copyright 2024 Adevinta
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: write
+
+# Allow only one concurrent deployment, skipping runs queued between
+# the run in-progress and latest queued. However, do not cancel
+# in-progress runs as we want to allow these production deployments to
+# complete.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Release
+        run: go run release.go
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 # Copyright 2023 Adevinta
 
-name: Main
+name: Test
 on: [push, pull_request]
 permissions:
   contents: read

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module release
+
+go 1.21.6
+
+require golang.org/x/mod v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=

--- a/release.go
+++ b/release.go
@@ -1,0 +1,122 @@
+// Copyright 2024 Adevinta
+
+/*
+Release publishes a new GitHub release.
+
+It expects an environment variable with the name GITHUB_REF_NAME. The
+value of GITHUB_REF_NAME must be a git tag with a valid semantic
+version (e.g. v1.2.3).
+
+For a given tag, it creates three releases:
+
+  - vMAJOR
+  - vMAJOR.MINOR
+  - vMAJOR.MINOR.PATCH
+
+If the version in the tag name corresponds to a prerelease, only
+vMAJOR.MINOR.PATCH-PRERELEASE is created.
+
+For instance, if the tag is v1.2.3, the following releases will be
+created:
+
+  - v1     (updated if it already exists)
+  - v1.2   (updated if it already exists)
+  - v1.2.3
+
+This release schema allows users to pin versions depending on their
+needs. In other words,
+
+  - v1.2.3  :=  ==v1.2.3
+  - v1.2    :=  >=v1.2.0, <v1.3.0
+  - v1      :=  >=v1.0.0, <v2.0.0
+  - v0.2.3  :=  ==v0.2.3
+  - v0.2    :=  >=v0.2.0, <v0.3.0
+  - v0      :=  >=v0.0.0, <v1.0.0
+*/
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+func main() {
+	log.SetFlags(0)
+
+	refName := os.Getenv("GITHUB_REF_NAME")
+	if refName == "" {
+		log.Fatalf("error: missing env var GITHUB_REF_NAME")
+	}
+
+	if !semver.IsValid(refName) {
+		log.Fatalf("error: invalid version %q", refName)
+	}
+
+	hash, err := gitHash(refName)
+	if err != nil {
+		log.Fatalf("error: get hash: %v", err)
+	}
+
+	// Do not create vMAJOR and vMAJOR.MINOR for pre-releases.
+	releases := []string{refName}
+	if semver.Prerelease(refName) == "" {
+		releases = append(releases, semver.Major(refName), semver.MajorMinor(refName))
+	}
+
+	for _, r := range releases {
+		// Do not update vMAJOR.MINOR.PATCH.
+		update := r != refName
+
+		if err := ghRelease(r, hash, update); err != nil {
+			log.Fatalf("error: create GitHub release %q: %v", r, err)
+		}
+	}
+}
+
+// gitHash returns the hash corresponding to the specified reference
+// using "git show-ref".
+func gitHash(ref string) (string, error) {
+	hash, err := cmdOutput("git", "show-ref", "--hash", ref)
+	if err != nil {
+		return "", fmt.Errorf("git show-ref: %w", err)
+	}
+	return hash, nil
+}
+
+// ghRelease creates a GitHub release using "gh release". If update is
+// true, it first tries to delete any existing release with the same
+// tag.
+func ghRelease(tag, target string, update bool) error {
+	if update {
+		if _, err := cmdOutput("gh", "release", "delete", "--cleanup-tag", "--yes", tag); err != nil {
+			log.Printf("warn: could not delete release %q", tag)
+		}
+	}
+
+	args := []string{"release", "create", "--target", target, tag}
+	if _, err := cmdOutput("gh", args...); err != nil {
+		return fmt.Errorf("gh release create: %w", err)
+	}
+
+	return nil
+}
+
+// cmdOutput runs the specified command and returns its standard
+// output. The returned output is trimmed. In case of error, it
+// returns stderr along with the error.
+func cmdOutput(name string, arg ...string) (string, error) {
+	stderr := &bytes.Buffer{}
+	cmd := exec.Command(name, arg...)
+	cmd.Stderr = stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("cmd output: %w: %#q", err, stderr)
+	}
+	return strings.TrimSpace(string(out)), nil
+}


### PR DESCRIPTION
After pushing a tag with a semantic version, three releases are
created:

  - `vMAJOR`
  - `vMAJOR.MINOR`
  - `vMAJOR.MINOR.PATCH`

If the version in the tag name corresponds to a prerelease, only
`vMAJOR.MINOR.PATCH-PRERELEASE` is created.