### PR TITLE
lava-action: remove setup-go step

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,8 @@ jobs:
           exit 1
   test-defaults:
     env:
-      WANT_MIN_STATUS: 103 # ExitCodeHigh
+      WANT_MIN_STATUS: 100 # ExitCodeInfo
+      WANT_MAX_STATUS: 104 # ExitCodeCritical
     name: Test defaults
     runs-on: ubuntu-latest
     steps:
@@ -46,9 +47,9 @@ jobs:
       - name: Print report
         run: 'cat "${{ steps.lava.outputs.report }}"'
       - name: Report unexpected status
-        if: ${{ steps.lava.outputs.status < env.WANT_MIN_STATUS }}
+        if: ${{ steps.lava.outputs.status < env.WANT_MIN_STATUS || steps.lava.outputs.status > env.WANT_MAX_STATUS }}
         run: |
-          echo "::error::unexpected status code: got: ${{ steps.lava.outputs.status }}, want: >= ${{ env.WANT_MIN_STATUS }}"
+          echo "::error::unexpected status code: got: ${{ steps.lava.outputs.status }}, want: [${{ env.WANT_MIN_STATUS }}, ${{ env.WANT_MAX_STATUS }}]"
           exit 1
   test-release:
     env:
@@ -82,6 +83,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
       - name: Run Lava Action
         id: lava
         uses: ./

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21'
       - name: Run Lava Action

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Run Lava Action
-        uses: adevinta/lava-action@main
+        uses: adevinta/lava-action@v0
 ```
 
 ## Settings
@@ -34,7 +34,7 @@ The `version` input parameter specifies the version of Lava to use.
 
 ```yaml
 - name: Run Lava Action
-  uses: adevinta/lava-action@main
+  uses: adevinta/lava-action@v0
   with:
     version: latest
 ```
@@ -47,7 +47,7 @@ The path is relative to the root of the repository.
 
 ```yaml
 - name: Run Lava Action
-  uses: adevinta/lava-action@main
+  uses: adevinta/lava-action@v0
   with:
     config: lava.yaml
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -21,10 +21,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.21'
     - name: Run Lava
       id: lava
       run: '"${GITHUB_ACTION_PATH}/run.bash"'

--- a/run.bash
+++ b/run.bash
@@ -13,12 +13,8 @@ install_lava() {
 		url=$(printf "${GH_DOWNLOAD_URL_FMT}" "${version}")
 	fi
 
-	# Make sure the install directory exists.
-	install_dir="$(go env GOPATH)/bin"
-	mkdir -p "${install_dir}"
-
 	# Try to download a Lava release from GitHub.
-	if (curl -LsSf "${url}" | tar -xz -C "${install_dir}" lava) 2> /dev/null; then
+	if (curl -LsSf "${url}" | sudo tar -xz -C "/usr/local/bin" lava) 2> /dev/null; then
 		return 0
 	fi
 


### PR DESCRIPTION
This step is only required when the `version` input points to a Lava
version that does not have an associated release. Most probably
because the user wants to use a development version. In that case, it
seems fair to require the user to setup a proper Go environment in
their workflow.