### PR TITLE
lava-action: force colorized output via environment variable

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -56,7 +56,7 @@ fi
 config=${LAVA_CONFIG:-"${GITHUB_ACTION_PATH}/default.yaml"}
 output=$(mktemp)
 
-lava scan -forcecolor="${LAVA_FORCECOLOR}" -c "${config}" > "${output}"
+lava scan -c "${config}" > "${output}"
 status=$?
 
 echo "status=${status}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
After adevinta/lava#68 colorized output is set using the
`LAVA_FORCECOLOR` environment variable.