### PR TITLE
lava-action: use existing lava.yaml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,10 +5,11 @@ on: [push, pull_request]
 permissions:
   contents: read
 jobs:
-  test:
+  test-config:
     env:
       WANT_STATUS: 103 # ExitCodeHigh
-    name: Test
+      WANT_CONFIG: testdata/lava.yaml
+    name: Test config
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -24,16 +25,22 @@ jobs:
         run: 'echo "Lava status: ${{ steps.lava.outputs.status }}"'
       - name: Print report
         run: 'cat "${{ steps.lava.outputs.report }}"'
+      - name: Report unexpected config file
+        if: ${{ !endsWith(steps.lava.outputs.config, env.WANT_CONFIG) }}
+        run: |
+          echo "::error::unexpected config file: got: ${{ steps.lava.outputs.config }}, want: ${{ env.WANT_CONFIG }}"
+          exit 1
       - name: Report unexpected status
         if: ${{ steps.lava.outputs.status != env.WANT_STATUS }}
         run: |
           echo "::error::unexpected status code: got: ${{ steps.lava.outputs.status }}, want: ${{ env.WANT_STATUS }}"
           exit 1
-  test-defaults:
+  test-default-yaml:
     env:
       WANT_MIN_STATUS: 100 # ExitCodeInfo
       WANT_MAX_STATUS: 104 # ExitCodeCritical
-    name: Test defaults
+      WANT_CONFIG: default.yaml
+    name: Test default.yaml
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -46,10 +53,44 @@ jobs:
         run: 'echo "Lava status: ${{ steps.lava.outputs.status }}"'
       - name: Print report
         run: 'cat "${{ steps.lava.outputs.report }}"'
+      - name: Report unexpected config file
+        if: ${{ !endsWith(steps.lava.outputs.config, env.WANT_CONFIG) }}
+        run: |
+          echo "::error::unexpected config file: got: ${{ steps.lava.outputs.config }}, want: ${{ env.WANT_CONFIG }}"
+          exit 1
       - name: Report unexpected status
         if: ${{ steps.lava.outputs.status < env.WANT_MIN_STATUS || steps.lava.outputs.status > env.WANT_MAX_STATUS }}
         run: |
           echo "::error::unexpected status code: got: ${{ steps.lava.outputs.status }}, want: [${{ env.WANT_MIN_STATUS }}, ${{ env.WANT_MAX_STATUS }}]"
+          exit 1
+  test-lava-yaml:
+    env:
+      WANT_STATUS: 103 # ExitCodeHigh
+      WANT_CONFIG: lava.yaml
+    name: Test lava.yaml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Lava Action
+        id: lava
+        uses: ./
+        env:
+          TEST_WORKDIR: testdata
+        continue-on-error: true
+      - name: Print status
+        run: 'echo "Lava status: ${{ steps.lava.outputs.status }}"'
+      - name: Print report
+        run: 'cat "${{ steps.lava.outputs.report }}"'
+      - name: Report unexpected config file
+        if: ${{ !endsWith(steps.lava.outputs.config, env.WANT_CONFIG) }}
+        run: |
+          echo "::error::unexpected config file: got: ${{ steps.lava.outputs.config }}, want: ${{ env.WANT_CONFIG }}"
+          exit 1
+      - name: Report unexpected status
+        if: ${{ steps.lava.outputs.status != env.WANT_STATUS }}
+        run: |
+          echo "::error::unexpected status code: got: ${{ steps.lava.outputs.status }}, want: ${{ env.WANT_STATUS }}"
           exit 1
   test-release:
     env:
@@ -63,7 +104,7 @@ jobs:
         id: lava
         uses: ./
         with:
-          version: v0.2.0
+          version: v0.5.0
           config: testdata/lava.yaml
         continue-on-error: true
       - name: Print status

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ The path is relative to the root of the repository.
     config: lava.yaml
 ```
 
+If the parameter is missing the action will use an existing `lava.yaml` file,
+or the [default.yaml] otherwhise.
+
+```yaml
+- name: Run Lava Action
+  uses: adevinta/lava-action@v0
+```
+
 ## Contributing
 
 **This project is in an early stage, we are not accepting external
@@ -63,3 +71,4 @@ guidelines][contributing].
 
 [lava]: https://github.com/adevinta/lava
 [contributing]: /CONTRIBUTING.md
+[default.yaml]: /default.yaml

--- a/action.yaml
+++ b/action.yaml
@@ -1,7 +1,7 @@
 # Copyright 2023 Adevinta
 
 name: Lava
-description: Run Lava
+description: Run Lava.
 inputs:
   config:
     description: Path of the Lava configuration file.
@@ -10,14 +10,17 @@ inputs:
     default: latest
   forcecolor:
     description: Force colorized output.
-    default: true
+    default: "true"
 outputs:
   status:
-    description: Status code
+    description: Status code.
     value: ${{ steps.lava.outputs.status }}
   report:
-    description: Path of the Lava report
+    description: Path of the Lava report.
     value: ${{ steps.lava.outputs.report }}
+  config:
+    description: Path to the used Lava configuration file.
+    value: ${{ steps.lava.outputs.config }}
 runs:
   using: composite
   steps:

--- a/run.bash
+++ b/run.bash
@@ -44,6 +44,18 @@ if [[ -z $LAVA_FORCECOLOR ]]; then
 	exit 2
 fi
 
+if [[ -n $TEST_WORKDIR ]]; then
+	cd "$TEST_WORKDIR" || { echo 'error: could not cd to TEST_WORKDIR' >&2 ; exit 2; }
+fi
+
+if [[ -n $LAVA_CONFIG ]]; then
+	config=$LAVA_CONFIG
+elif [[ -f lava.yaml ]]; then
+	config=lava.yaml
+else
+	config="${GITHUB_ACTION_PATH}/default.yaml"
+fi
+
 # Install Lava.
 
 if ! install_lava "${LAVA_VERSION}"; then
@@ -53,14 +65,16 @@ fi
 
 # Run Lava.
 
-config=${LAVA_CONFIG:-"${GITHUB_ACTION_PATH}/default.yaml"}
 output=$(mktemp)
 
 lava scan -c "${config}" > "${output}"
 status=$?
 
-echo "status=${status}" >> "${GITHUB_OUTPUT}"
-echo "report=${output}" >> "${GITHUB_OUTPUT}"
+{
+echo "status=${status}"
+echo "report=${output}"
+echo "config=${config}"
+} > "${GITHUB_OUTPUT}"
 
 cat "${output}"
 echo "exit status ${status}"

--- a/testdata/lava.yaml
+++ b/testdata/lava.yaml
@@ -1,8 +1,8 @@
 lava: v0.0.0
 checktypes:
-  - testdata/checktypes.json
+  - ${GITHUB_WORKSPACE}/testdata/checktypes.json
 targets:
-  - identifier: .
+  - identifier: ${GITHUB_WORKSPACE}
     type: GitRepository
 report:
   severity: high


### PR DESCRIPTION
This pr updates the behaviour when config is not provided by checking if an existing `lava.yaml` exists.