### PR TITLE
lava-action: prevent fail when no permission

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -260,3 +260,38 @@ jobs:
             if (!comment) {
               core.setFailed('PR comment not generated');
             }
+
+  test-no-permissions:
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      WANT_STATUS: 103 # ExitCodeHigh
+      WANT_OUTCOME: success
+    name: Test no pull-request permissions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Lava Action
+        id: lava
+        uses: ./
+        with:
+          version: latest
+          config: testdata/lava.yaml
+          comment-pr: 'true'
+        continue-on-error: true
+      - name: Print status
+        run: 'echo "Lava status: ${{ steps.lava.outputs.status }}"'
+      - name: Print report
+        run: 'cat "${{ steps.lava.outputs.report }}"'
+      - name: Report unexpected status
+        if: ${{ steps.lava.outputs.status != env.WANT_STATUS }}
+        run: |
+          echo "::error::unexpected status code: got: ${{ steps.lava.outputs.status }}, want: ${{ env.WANT_STATUS }}"
+          exit 1
+      - name: Report unexpected outcome
+        if: steps.lava.outcome == env.WANT_OUTCOME
+        run: |
+          echo "::error::unexpected outcome: got: ${{ steps.lava.outcome }}, want: ${{ env.WANT_OUTCOME }}"
+          exit 1

--- a/report.js
+++ b/report.js
@@ -2,7 +2,7 @@
 
 // This module generates summaries and comments pull requests based on the Lava results.
 
-const fs=require('fs')
+const fs = require('fs')
 
 function generateSummary(core, metrics) {
   var body = '### Lava scan results\n\n';
@@ -79,5 +79,15 @@ module.exports.postComment = async (github, context, core) => {
   // eslint-disable-next-line no-undef
   const metrics = JSON.parse(fs.readFileSync(process.env.METRICS, 'utf8'));
   const summary = generateSummary(core, metrics);
-  await comment(github, context, summary);
+  try {
+    await comment(github, context, summary);
+  } catch (e) {
+    console.log(e);
+    core.summary
+      .addHeading(':warning: Unable to create pull request comment', 4)
+      .addRaw('Error:', true).addQuote(e)
+      .addRaw('Remember to grant the required permissions to the job (or disable comment-pr option).', true)
+      .addCodeBlock('permissions:\n  pull_request: write', 'yaml')
+      .write();
+  }
 }


### PR DESCRIPTION
This pull_request prevents the action to fail in case of `comment-pr` activated and no permissions configured.
Also, it generates a step summary with directions to fix the problem.