### PR TITLE
lava-action: use -fullreport and -metrics flags

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,6 @@ jobs:
     env:
       WANT_STATUS: 103 # ExitCodeHigh
       WANT_CONFIG: testdata/lava.yaml
-      WANT_METRICS: /configured-metrics.json
     name: Test config
     runs-on: ubuntu-latest
     steps:
@@ -58,16 +57,22 @@ jobs:
             }
       - name: Report unexpected metrics file
         run: |
-          if [[ "${{ steps.lava.outputs.metrics }}" != *"${{ env.WANT_METRICS }}"* ]]; then
-            echo "::error::unexpected status metrics output: got: ${{ steps.lava.outputs.metrics }}, want: ${{ env.WANT_METRICS }}"
-            exit 1
-          fi
           if [ ! -f "${{ steps.lava.outputs.metrics }}" ]; then
             echo "::error::metrics file not found"
             exit 1
           fi
-          if [[ "$(jq -r '.exit_code' "${{ steps.lava.outputs.metrics }}" )" != "${{ steps.lava.outputs.status }}" ]]; then
-            echo "::error::metrics wrong content"
+          if [[ $(jq -r '.exit_code' "${{ steps.lava.outputs.metrics }}") != ${{ steps.lava.outputs.status }} ]]; then
+            echo "::error::malformed metrics file"
+            exit 1
+          fi
+      - name: Report unexpected full report file
+        run: |
+          if [ ! -f "${{ steps.lava.outputs.fullreport }}" ]; then
+            echo "::error::full report file not found"
+            exit 1
+          fi
+          if [[ $(jq -r '.vulnerabilities|length' "${{ steps.lava.outputs.fullreport }}") == 0 ]]; then
+            echo "::error::malformed full report"
             exit 1
           fi
 
@@ -76,7 +81,6 @@ jobs:
       WANT_MIN_STATUS: 100 # ExitCodeInfo
       WANT_MAX_STATUS: 104 # ExitCodeCritical
       WANT_CONFIG: default.yaml
-      WANT_METRICS: metrics-injected
     name: Test default.yaml
     runs-on: ubuntu-latest
     steps:
@@ -120,16 +124,22 @@ jobs:
             }
       - name: Report unexpected metrics file
         run: |
-          if [[ "${{ steps.lava.outputs.metrics }}" != *"${{ env.WANT_METRICS }}"* ]]; then
-            echo "::error::unexpected status metrics output: got: ${{ steps.lava.outputs.metrics }}, want: ${{ env.WANT_METRICS }}"
-            exit 1
-          fi
           if [ ! -f "${{ steps.lava.outputs.metrics }}" ]; then
             echo "::error::metrics file not found"
             exit 1
           fi
-          if [[ "$(jq -r '.exit_code' "${{ steps.lava.outputs.metrics }}" )" != "${{ steps.lava.outputs.status }}" ]]; then
-            echo "::error::metrics wrong content"
+          if [[ $(jq -r '.exit_code' "${{ steps.lava.outputs.metrics }}") != ${{ steps.lava.outputs.status }} ]]; then
+            echo "::error::malformed metrics file"
+            exit 1
+          fi
+      - name: Report unexpected full report file
+        run: |
+          if [ ! -f "${{ steps.lava.outputs.fullreport }}" ]; then
+            echo "::error::full report file not found"
+            exit 1
+          fi
+          if [[ $(jq -r '.vulnerabilities|length' "${{ steps.lava.outputs.fullreport }}") == 0 ]]; then
+            echo "::error::malformed full report"
             exit 1
           fi
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,11 +15,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
       - name: Run Lava Action
         id: lava
         uses: ./
         with:
-          version: latest
+          version: output
           config: testdata/lava.yaml
           comment-pr: 'true'
         continue-on-error: true
@@ -86,9 +90,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
       - name: Run Lava Action
         id: lava
         uses: ./
+        with:
+          version: output
         continue-on-error: true
       - name: Print status
         run: 'echo "Lava status: ${{ steps.lava.outputs.status }}"'
@@ -152,12 +162,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
       - name: Run Lava Action
         id: lava
         uses: ./
         env:
           TEST_WORKDIR: testdata
         with:
+          version: output
           comment-pr: 'true'
         continue-on-error: true
       - name: Print status
@@ -174,6 +189,7 @@ jobs:
         run: |
           echo "::error::unexpected status code: got: ${{ steps.lava.outputs.status }}, want: ${{ env.WANT_STATUS }}"
           exit 1
+
   test-release:
     env:
       WANT_STATUS: 103 # ExitCodeHigh
@@ -182,11 +198,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
       - name: Run Lava Action
         id: lava
         uses: ./
         with:
-          version: v0.5.0
+          version: output
           config: testdata/lava.yaml
         continue-on-error: true
       - name: Print status
@@ -198,6 +218,7 @@ jobs:
         run: |
           echo "::error::unexpected status code: got: ${{ steps.lava.outputs.status }}, want: ${{ env.WANT_STATUS }}"
           exit 1
+
   test-branch:
     env:
       WANT_STATUS: 103 # ExitCodeHigh
@@ -214,7 +235,7 @@ jobs:
         id: lava
         uses: ./
         with:
-          version: main
+          version: output
           config: testdata/lava.yaml
         continue-on-error: true
       - name: Print status
@@ -235,10 +256,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
       - name: Run Lava Action
         id: lava
         uses: ./
         with:
+          version: output
           comment-pr: 'true'
         env:
           TEST_WORKDIR: .github
@@ -283,11 +309,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
       - name: Run Lava Action
         id: lava
         uses: ./
         with:
-          version: latest
+          version: output
           config: testdata/lava.yaml
           comment-pr: 'true'
         continue-on-error: true

--- a/action.yaml
+++ b/action.yaml
@@ -25,8 +25,11 @@ outputs:
     description: Path to the used Lava configuration file.
     value: ${{ steps.lava.outputs.config }}
   metrics:
-    description: Path to the metrics generated file.
+    description: Path to the generated metrics file.
     value: ${{ steps.lava.outputs.metrics }}
+  fullreport:
+    description: Path to the generated full report file.
+    value: ${{ steps.lava.outputs.fullreport }}
 runs:
   using: composite
   steps:
@@ -42,7 +45,7 @@ runs:
       uses: actions/github-script@v7
       if: ${{ !cancelled() }}
       env:
-        METRICS: ${{ steps.lava.outputs.metrics }}
+        FULLREPORT: ${{ steps.lava.outputs.fullreport }}
         COMMENT_PR: ${{ inputs.comment-pr }}
       with:
         script: |
@@ -52,7 +55,7 @@ runs:
       uses: actions/github-script@v7
       if: ${{ !cancelled() && github.event_name=='pull_request' && inputs.comment-pr=='true' }}
       env:
-        METRICS: ${{ steps.lava.outputs.metrics }}
+        FULLREPORT: ${{ steps.lava.outputs.fullreport }}
       with:
         script: |
           const report = require(`${process.env.GITHUB_ACTION_PATH}/report.js`);

--- a/report.js
+++ b/report.js
@@ -1,33 +1,34 @@
 // Copyright 2024 Adevinta
 
-// This module generates summaries and comments pull requests based on the Lava results.
+// This module generates summaries and comments pull requests based on
+// the Lava results.
 
 const fs = require('fs')
 
-function generateSummary(core, metrics) {
+function generateSummary(core, fullreport) {
   var body = '### Lava scan results\n\n';
 
-  if (!metrics.vulnerability_count || Object.keys(metrics.vulnerability_count).length === 0) {
+  if (!fullreport.summary || !fullreport.summary.count || Object.keys(fullreport.summary.count).length === 0) {
     return body + `No vulnerabilities found! 🎉\n\n`;
   }
 
   body += `| Severity | Findings |\n`;
   body += `|---|---:|\n`;
 
-  if (metrics.vulnerability_count["critical"] > 0) {
-    body += `| 🟣 Critical | ${metrics.vulnerability_count["critical"]} |\n`;
+  if (fullreport.summary.count.critical && fullreport.summary.count.critical > 0) {
+    body += `| 🟣 Critical | ${fullreport.summary.count.critical} |\n`;
   }
-  if (metrics.vulnerability_count["high"] > 0) {
-    body += `| 🔴 High | ${metrics.vulnerability_count["high"]} |\n`;
+  if (fullreport.summary.count.high && fullreport.summary.count.high > 0) {
+    body += `| 🔴 High | ${fullreport.summary.count.high} |\n`;
   }
-  if (metrics.vulnerability_count["medium"] > 0) {
-    body += `| 🟠 Medium | ${metrics.vulnerability_count["medium"]} |\n`;
+  if (fullreport.summary.count.medium && fullreport.summary.count.medium > 0) {
+    body += `| 🟠 Medium | ${fullreport.summary.count.medium} |\n`;
   }
-  if (metrics.vulnerability_count["low"] > 0) {
-    body += `| 🟡 Low | ${metrics.vulnerability_count["low"]} |\n`;
+  if (fullreport.summary.count.low && fullreport.summary.count.low > 0) {
+    body += `| 🟡 Low | ${fullreport.summary.count.low} |\n`;
   }
-  if (metrics.vulnerability_count["info"] > 0) {
-    body += `| 🔵 Info | ${metrics.vulnerability_count["info"]} |\n`;
+  if (fullreport.summary.count.info && fullreport.summary.count.info > 0) {
+    body += `| 🔵 Info | ${fullreport.summary.count.info} |\n`;
   }
   return body;
 }
@@ -66,19 +67,21 @@ async function comment(github, context, summary) {
   })
 }
 
-// writeSummary writes a step job summary based on the metrics file.
+// writeSummary writes a step job summary based on the full report
+// file.
 module.exports.writeSummary = async (core) => {
   // eslint-disable-next-line no-undef
-  const metrics = JSON.parse(fs.readFileSync(process.env.METRICS, 'utf8'));
-  const summary = generateSummary(core, metrics);
+  const fullreport = JSON.parse(fs.readFileSync(process.env.FULLREPORT, 'utf8'));
+  const summary = generateSummary(core, fullreport);
   core.summary.addRaw(summary).write();
 }
 
-// postComment creates or updates a comment in the pull request based on the metrics file.
+// postComment creates or updates a comment in the pull request based
+// on the full report file.
 module.exports.postComment = async (github, context, core) => {
   // eslint-disable-next-line no-undef
-  const metrics = JSON.parse(fs.readFileSync(process.env.METRICS, 'utf8'));
-  const summary = generateSummary(core, metrics);
+  const fullreport = JSON.parse(fs.readFileSync(process.env.FULLREPORT, 'utf8'));
+  const summary = generateSummary(core, fullreport);
   try {
     await comment(github, context, summary);
   } catch (e) {

--- a/run.bash
+++ b/run.bash
@@ -2,7 +2,6 @@
 
 GH_DOWNLOAD_URL_FMT='https://github.com/adevinta/lava/releases/download/%s/lava_linux_amd64.tar.gz'
 GH_DOWNLOAD_URL_LATEST='https://github.com/adevinta/lava/releases/latest/download/lava_linux_amd64.tar.gz'
-YQ_VERSION=${YQ_VERSION:-v4.44.1}
 
 install_lava() {
 	local version=$1
@@ -65,40 +64,20 @@ if ! install_lava "${LAVA_VERSION}"; then
 	exit 1
 fi
 
-if ! which yq &> /dev/null; then
-	if ! (wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz" -O - | tar xz && sudo mv yq_linux_amd64 /usr/local/bin/yq) 2> /dev/null; then
-		echo 'error: could not install yq' >&2
-		exit 1
-	fi
-fi
-
-# This action needs the metrics, so if not set it is forced.
-metrics=$(yq '.report.metrics' "${config}")
-if [[ "$metrics" == "null" ]]; then
-	metrics=$(mktemp -t metrics-injected-XXXX)
-	original_config=$config
-	config=$(mktemp)
-	metrics=$metrics yq eval '.report.metrics = strenv(metrics)' "${original_config}" > "${config}"
-else
-	metrics=$(realpath "$metrics")
-fi
-
 # Run Lava.
 
-output=$(mktemp)
+fullreport=$(mktemp -t 'lava-fullreport-XXXXXXXXXX.json')
+metrics=$(mktemp -t 'lava-metrics-XXXXXXXXXX.json')
+output=$(mktemp -t 'lava-output-XXXXXXXXXX')
 
-lava scan -c "${config}" > "${output}"
+lava scan -c="${config}" -fullreport="${fullreport}" -metrics="${metrics}" > "${output}"
 status=$?
-
-# Restore original config
-if [[ "$original_config" != "" ]]; then
-	config=$original_config
-fi
 
 {
 echo "status=${status}"
 echo "report=${output}"
 echo "config=${config}"
+echo "fullreport=${fullreport}"
 echo "metrics=${metrics}"
 } > "${GITHUB_OUTPUT}"
 

--- a/testdata/lava.yaml
+++ b/testdata/lava.yaml
@@ -6,4 +6,3 @@ targets:
     type: GitRepository
 report:
   severity: high
-  metrics: ./configured-metrics.json


### PR DESCRIPTION
This PR updates the action to use the new `-fullreport` and `-metrics`
flags introduced by adevinta/lava#89.